### PR TITLE
Fix PhantomJS Issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,9 @@ function capitalize(str){
 
 function dashedPrefix(key){
   key = prefix(key)
-  if (upper.test(key)) key = '-' + key.replace(upper, '-$1')
+  if (upper.test(key)) {
+    key = '-' + key.replace(upper, '-$1')
+    upper.lastIndex = 0;
+  }
   return key.toLowerCase()
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "prefix a css attribute",
   "dependencies": {},
   "devDependencies": {
-    "serve": "jkroso/serve#1.5.1",
-    "assert": "component/assert",
-    "mocha": "*"
+    "mocha": "^2.2.5",
+    "serve": "jkroso/serve#1.5.1"
   },
   "repository": "git://github.com/jkroso/prefix.git",
   "bugs": "https://github.com/jkroso/prefix/issues",

--- a/test/prefix.test.js
+++ b/test/prefix.test.js
@@ -1,5 +1,5 @@
 
-var assert = require('assert/index')
+var assert = require('assert')
 var prefix = require('..')
 var dash = prefix.dash
 

--- a/test/prefix.test.js
+++ b/test/prefix.test.js
@@ -31,14 +31,23 @@ describe('prefix', function(){
 })
 
 describe('dash', function(){
-  it('should create a dasherized string', function(){
-    assert(dash('transform') in {
+  var transformPossibilites = {
       '-webkit-transform': null,
       '-moz-transform': null,
       '-ms-transform': null,
       '-o-transform': null,
       'transform': null
-    })
+  }
+
+  it('should create a dasherized string', function(){
+    assert(dash('transform') in transformPossibilites)
+  })
+
+  it('should work if invoked many times', function(){
+      assert(dash('transform') in transformPossibilites)
+      assert(dash('transform') in transformPossibilites)
+      assert(dash('transform') in transformPossibilites)
+      assert(dash('transform') in transformPossibilites)
   })
 })
 


### PR DESCRIPTION
It seems there is a bug in PhantomJS where calling `String.prototype.replace()` does _not_ reset the `lastIndex` of a global regular expression.

In phantom, the following would happen:

``` javascript
dash('transform') // -webkit-transform
dash('transform') // webkittransform
dash('transform') // -webkit-transform
dash('transform') // webkittransform
```

[This SO answer explains the issue a bit.](http://stackoverflow.com/questions/3827456/what-is-wrong-with-my-date-regex/3827500#3827500)

This PR fixes the issue by resetting the `lastIndex` of the `RegExp` after its `test()` method is called.
