### PR TITLE
Capitalize Webkit prefix

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -22,7 +22,7 @@ var prefix = require('prefix')
   Prefix `key`. This function memoizes its results so you don't need to worry about any performance issues, just treat it like a map.
 
 ```js
-prefix('transform') // => webkitTransform
+prefix('transform') // => WebkitTransform
 prefix('color') // => color
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 
 var style = document.createElement('p').style
-var prefixes = 'O ms Moz webkit'.split(' ')
+var prefixes = 'O ms Moz Webkit'.split(' ')
 var upper = /([A-Z])/g
 
 var memo = {}
@@ -25,7 +25,7 @@ exports.dash = dashedPrefix
 /**
  * prefix `key`
  *
- *   prefix('transform') // => webkitTransform
+ *   prefix('transform') // => WebkitTransform
  *
  * @param {String} key
  * @return {String}

--- a/test/prefix.test.js
+++ b/test/prefix.test.js
@@ -49,7 +49,7 @@ describe('dash', function(){
 })
 
 function possibilities(key){
-  return 'Moz O ms webkit'.split(' ').map(function(pre){
+  return 'Moz O ms Webkit'.split(' ').map(function(pre){
     return pre + capitalize(key)
   }).concat(key).reduce(function(o, k){
     o[k] = true


### PR DESCRIPTION
This capitalizes the Webkit vendor prefix per http://www.andismith.com/blog/2012/02/modernizr-prefixed/.  
